### PR TITLE
Migrate coverage from Coveralls to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: "Coverage"
 
 on:
   pull_request:
+  workflow_dispatch:
 
   push:
     branches: ["*"]
@@ -12,7 +13,7 @@ on:
 jobs:
   coverage:
     name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester-coverage.yml@v1
+    uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
     with:
       php: "8.4"
       make: "init coverage"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/tester-skeleton/actions"><img src="https://badgen.net/github/checks/contributte/tester-skeleton/master"></a>
-  <a href="https://coveralls.io/r/contributte/tester-skeleton"><img src="https://badgen.net/coveralls/c/github/contributte/tester-skeleton"></a>
+  <a href="https://codecov.io/gh/contributte/tester-skeleton"><img src="https://badgen.net/codecov/c/github/contributte/tester-skeleton"></a>
   <a href="https://packagist.org/packages/contributte/tester-skeleton"><img src="https://badgen.net/packagist/dm/contributte/tester-skeleton"></a>
   <a href="https://packagist.org/packages/contributte/tester-skeleton"><img src="https://badgen.net/packagist/v/contributte/tester-skeleton"></a>
 </p>

--- a/tests/.coveralls.yml
+++ b/tests/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: github-actions
-coverage_clover: coverage.xml
-json_path: coverage.json


### PR DESCRIPTION
Closes contributte/contributte#72.

## What changed
- switched the README coverage badge and link from Coveralls to Codecov
- migrated the coverage workflow to the shared Codecov-based reusable workflow
- removed the obsolete `tests/.coveralls.yml` file

## Why
- aligns this skeleton with the current Contributte coverage setup used in `contributte/vite`
- removes leftover Coveralls wiring now that coverage uploads go through Codecov