### PR TITLE
Use php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary
- replace `-p phpdbg` with `-p php` in the `coverage` target of `Makefile`
- align this skeleton with the org-wide coverage runner update tracked in contributte/contributte#73

## Motivation
- `phpdbg` is being removed from Contributte coverage targets in favor of running coverage with plain `php`

## Changes
- update the coverage command in `Makefile`

## Testing
- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification (if applicable)

Local `make coverage` currently fails in this environment because PHP is running without Xdebug, PCOV, or PHPDBG: `Code coverage functionality requires Xdebug or PCOV extension or PHPDBG SAPI (used php)`.